### PR TITLE
use pagination for queries with more than 50 results

### DIFF
--- a/jiraissues-plugin-sandbox/build.gradle
+++ b/jiraissues-plugin-sandbox/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "de.lxklssn.jiraissues" version "2.0.0"
+    id "de.lxklssn.jiraissues" version "2.0.1"
 }
 
 group 'de.lxklssn'

--- a/jiraissues-plugin/build.gradle
+++ b/jiraissues-plugin/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.11.0'
     id 'groovy'
+    id 'maven-publish'
 }
 
 sourceCompatibility = 1.8
@@ -28,7 +29,7 @@ gradlePlugin {
 ext {
     projectVersion = version
 }
-version = '2.0.0'
+version = '2.0.1'
 group 'de.lxklssn'
 
 pluginBundle {

--- a/jiraissues-plugin/src/main/groovy/de/lxklssn/jira/GetJiraIssuesTask.groovy
+++ b/jiraissues-plugin/src/main/groovy/de/lxklssn/jira/GetJiraIssuesTask.groovy
@@ -8,9 +8,6 @@ import org.gradle.api.tasks.TaskAction
 
 class GetJiraIssuesTask extends DefaultTask {
 
-    private static final String DATA = "data"
-    private static final String ISSUES = "issues"
-
     @Input
     final Property<String> jql = project.objects.property(String)
     @Input
@@ -33,8 +30,7 @@ class GetJiraIssuesTask extends DefaultTask {
         JiraRESTClient jiraRESTClient = new JiraRESTClient(jiraBaseUrl.get() + "/rest/api/2/", jiraUsername.get(), jiraPassword.get())
 
         fixVersions.get().each { fixVersion ->
-            def issuesResponse = jiraRESTClient.getIssues(fixVersion, jql.get())
-            List issues = issuesResponse.properties.get(DATA).getAt(ISSUES) as List
+            List issues = jiraRESTClient.getIssues(fixVersion, jql.get())
             snippetFileCreator.createIssueSnippet(fixVersion, issueChapterMapper.map(issues))
         }
     }

--- a/jiraissues-plugin/src/main/groovy/de/lxklssn/jira/JiraRESTClient.groovy
+++ b/jiraissues-plugin/src/main/groovy/de/lxklssn/jira/JiraRESTClient.groovy
@@ -85,10 +85,10 @@ class JiraRESTClient extends RESTClient {
         def issuesResponse = get("search", query)
         def responseData = issuesResponse.getProperties().get(DATA)
 
-        List newIssues = responseData.getAt(ISSUES) as List
+        def newIssues = responseData.getAt(ISSUES) as List
 
-        Integer maxResults = responseData.getAt("maxResults")
-        Integer totalResults = responseData.getAt("total")
+        def maxResults = responseData.getAt("maxResults")
+        def totalResults = responseData.getAt("total")
 
         totalResultsSoFar += newIssues.size()
         allIssues.addAll(newIssues)


### PR DESCRIPTION
Currently version 2.0.0 only supports result sets with 50 items, as it does not use pagination. This PR fixes this and implements pagination for larger result sets.

Also I added the `maven-publish` plugin, which makes it easier to publish a version locally and use it in another gradle project.

This closes #7 